### PR TITLE
Make HitObject an Abstract Function

### DIFF
--- a/vsrg/EventObject.h
+++ b/vsrg/EventObject.h
@@ -11,5 +11,6 @@ class EventObject : public TimedObject
 public:
 	EventObject(double offset_m_sec);
 	~EventObject() = 0;
+	virtual std::shared_ptr<TimedObject> Clone() const override = 0;
 };
 

--- a/vsrg/HitObject.cpp
+++ b/vsrg/HitObject.cpp
@@ -8,19 +8,17 @@ HitObject::HitObject(const double & offset_m_sec,
 	setColumn(column, starts_from);
 }
 
-HitObject::~HitObject()
-{
-}
+HitObject::~HitObject() {}
 
 std::string HitObject::getInfo() const {
 	return TimedObject::getInfo() +
 		"Column " + std::to_string(column_) + '\n';
 }
 
-bool HitObject::operator==(const HitObject & ho) const
+bool HitObject::operator==(const std::shared_ptr<HitObject>& ho) const
 {
-	return (getOffsetMSec() == ho.getOffsetMSec()) &&
-		(getColumn() == ho.getColumn());
+	return (getOffsetMSec() == ho->getOffsetMSec()) &&
+		(getColumn() == ho->getColumn());
 }
 
 bool HitObject::isValid() const {
@@ -36,7 +34,7 @@ void HitObject::setColumn(const int & column, const int & starts_from) {
 	column_ = column - starts_from;
 }
 
-bool HitObject::isOverlapping(const HitObject & ho) const
+bool HitObject::isOverlapping(const std::shared_ptr<HitObject>& ho) const
 {
-	return (this->operator==(ho));
+	return operator==(ho);
 }

--- a/vsrg/HitObject.h
+++ b/vsrg/HitObject.h
@@ -15,8 +15,8 @@ public:
 	 * @param starts_from Specify from what index the column starts from
 	 */
 	HitObject(const double & offset_m_sec, const int & column, const int & starts_from = 0);
-	~HitObject(); // TODO: Make this virtual and move tests to separate categories
-
+	~HitObject() = 0;
+	virtual std::shared_ptr<TimedObject> Clone() const override = 0;
 	/// Gets the column, specify starts_from to offset it to the correct index
 	int getColumn(const int & starts_from = 0) const;
 
@@ -24,7 +24,8 @@ public:
 	void setColumn(const int & column, const int & starts_from = 0);
 
 	/// Checks if 2 objects are overlapping. An alias to operator==
-	virtual bool isOverlapping(const HitObject & ho) const;
+	//virtual bool isOverlapping(const HitObject & ho) const;
+	virtual bool isOverlapping(const std::shared_ptr<HitObject> & ho) const;
 
 	/// Validates the object being realistic
 	virtual bool isValid() const override;
@@ -32,7 +33,7 @@ public:
 	/// Gets info of the important object members
 	virtual std::string getInfo() const override;
 
-	virtual bool operator==(const HitObject & ho) const;
+	virtual bool operator==(const std::shared_ptr<HitObject> & ho) const;
 
 private:
 	int column_;

--- a/vsrg/LongNote.cpp
+++ b/vsrg/LongNote.cpp
@@ -4,14 +4,10 @@
 LongNote::LongNote(SPtrHitObject start_ho, SPtrHitObject end_ho) :
 	start_ho_(start_ho), end_ho_(end_ho) {}
 
-LongNote::LongNote(HitObject start_ho, HitObject end_ho) {
-	start_ho_ = std::make_shared<HitObject>(start_ho);
-	end_ho_ = std::make_shared<HitObject>(end_ho);
-}
-
 LongNote::LongNote(const LongNote & ln) {
-	start_ho_ = std::make_shared<HitObject>(*ln.getStartNote());
-	end_ho_ = std::make_shared<HitObject>(*ln.getEndNote());
+	// Dynamic Pointer cast to promote from TimedObject to HitObject
+	start_ho_ = std::dynamic_pointer_cast<HitObject>(ln.getStartNote()->Clone());
+	end_ho_ = std::dynamic_pointer_cast<HitObject>(ln.getEndNote()->Clone());
 }
 
 LongNote::~LongNote()
@@ -80,14 +76,15 @@ LongNote::operator std::string() const
 bool LongNote::operator==(const LongNote & ln) const
 {
 	// Equivalent of comparing the HitObjects of the lns
-	return (getStartNote()->operator==(*ln.getStartNote())) &&
-		(getEndNote()->operator==(*ln.getEndNote()));
+	return (getStartNote() == ln.getStartNote()) &&
+		   (getEndNote() == ln.getEndNote());
 }
 
 LongNote & LongNote::operator=(const LongNote & ln)
 {
-	setStartNote(std::make_shared<HitObject>(*ln.getStartNote()));
-	setEndNote(std::make_shared<HitObject>(*ln.getEndNote()));
+	// Dynamic Pointer cast to promote from TimedObject to HitObject
+	setStartNote(std::dynamic_pointer_cast<HitObject>(ln.getStartNote()->Clone()));
+	setEndNote(std::dynamic_pointer_cast<HitObject>(ln.getEndNote()->Clone()));
 
 	return *this;
 }

--- a/vsrg/LongNote.h
+++ b/vsrg/LongNote.h
@@ -12,13 +12,6 @@ public:
 	 * @param end_ho The end Hit Object as a shared pointer
 	 */
 	LongNote(SPtrHitObject start_ho, SPtrHitObject end_ho);
-	/**
-	 * @brief Construct a new Long Note object
-	 *
-	 * @param start_ho The start Hit Object as a copy
-	 * @param end_ho The end Hit Object as a copy
-	 */
-	LongNote(HitObject start_ho, HitObject end_ho);
 	LongNote(const LongNote & ln);
 	~LongNote();
 

--- a/vsrg/NormalNote.cpp
+++ b/vsrg/NormalNote.cpp
@@ -13,3 +13,7 @@ NormalNote::NormalNote(const double & offset_m_sec,
 NormalNote::~NormalNote()
 {
 }
+
+std::shared_ptr<TimedObject> NormalNote::Clone() const {
+	return std::make_shared<NormalNote>(*this);
+}

--- a/vsrg/NormalNote.h
+++ b/vsrg/NormalNote.h
@@ -17,5 +17,6 @@ public:
 	 */
 	NormalNote(const double & offset_m_sec, const int & column, const int & starts_from = 0);
 	~NormalNote();
+	std::shared_ptr<TimedObject> Clone() const override;
 };
 

--- a/vsrg/ScrollPoint.cpp
+++ b/vsrg/ScrollPoint.cpp
@@ -8,6 +8,10 @@ ScrollPoint::~ScrollPoint()
 {
 }
 
+std::shared_ptr<TimedObject> ScrollPoint::Clone() const {
+	return std::make_shared<ScrollPoint>(*this);
+}
+
 double ScrollPoint::getScrollSpeedMult() const {
 	return scroll_speed_mult_;
 }

--- a/vsrg/ScrollPoint.h
+++ b/vsrg/ScrollPoint.h
@@ -16,6 +16,7 @@ public:
 	 */
 	ScrollPoint(double offset_m_sec, double scroll_speed_mult = 1.0);
 	~ScrollPoint();
+	virtual std::shared_ptr<TimedObject> Clone() const override;
 
 	double getScrollSpeedMult() const;
 	void setScrollSpeedMult(double scroll_speed_mult);

--- a/vsrg/TimedObject.h
+++ b/vsrg/TimedObject.h
@@ -14,7 +14,7 @@ public:
 	TimedObject(double offset_m_sec);
 	virtual ~TimedObject() = 0;
 
-	virtual std::shared_ptr<TimedObject> clone() const = 0;
+	virtual std::shared_ptr<TimedObject> Clone() const = 0;
 
 	/// Gets Offset in milliseconds
 	double getOffsetMSec() const; 

--- a/vsrg/TimingPoint.cpp
+++ b/vsrg/TimingPoint.cpp
@@ -9,6 +9,10 @@ TimingPoint::~TimingPoint()
 {
 }
 
+std::shared_ptr<TimedObject> TimingPoint::Clone() const {
+	return std::make_shared<TimingPoint>(*this);
+}
+
 double TimingPoint::getBpm() const {
 	return bpm_;
 }

--- a/vsrg/TimingPoint.h
+++ b/vsrg/TimingPoint.h
@@ -22,6 +22,7 @@ public:
 	 */
 	TimingPoint(double offset_m_sec, double bpm, double time_sig_numerator, double time_sig_denominator);
 	~TimingPoint();
+	virtual std::shared_ptr<TimedObject> Clone() const override;
 
 	double getBpm() const;
 	double getTimeSigNumerator() const;

--- a/vsrg/vsrg.vcxproj.filters
+++ b/vsrg/vsrg.vcxproj.filters
@@ -25,6 +25,9 @@
     <Filter Include="Wrapper Objects">
       <UniqueIdentifier>{7c124d07-02fe-43ba-b81b-868a54bf37f0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Wrapper Objects\Timed Objects">
+      <UniqueIdentifier>{5b03d687-e92f-495c-96bb-3a045a7dbc9e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -42,23 +45,26 @@
     <ClInclude Include="NormalNote.h">
       <Filter>Timed Objects\Hit Objects</Filter>
     </ClInclude>
+    <ClInclude Include="TimedObject.h">
+      <Filter>Timed Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="VsrgMap.h">
+      <Filter>Wrapper Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="TimedObjectVector.h">
+      <Filter>Wrapper Objects\Timed Objects</Filter>
+    </ClInclude>
+    <ClInclude Include="HitObjectVector.h">
+      <Filter>Wrapper Objects\Timed Objects</Filter>
+    </ClInclude>
     <ClInclude Include="EventObject.h">
       <Filter>Timed Objects\Event Objects</Filter>
     </ClInclude>
     <ClInclude Include="TimingPoint.h">
       <Filter>Timed Objects\Event Objects</Filter>
     </ClInclude>
-    <ClInclude Include="TimedObject.h">
-      <Filter>Timed Objects</Filter>
-    </ClInclude>
     <ClInclude Include="ScrollPoint.h">
       <Filter>Timed Objects\Event Objects</Filter>
-    </ClInclude>
-    <ClInclude Include="VsrgMap.h">
-      <Filter>Wrapper Objects</Filter>
-    </ClInclude>
-    <ClInclude Include="TimedObjectVector.h">
-      <Filter>Wrapper Objects</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -71,9 +77,6 @@
     <ClCompile Include="dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="EventObject.cpp">
-      <Filter>Timed Objects\Event Objects</Filter>
-    </ClCompile>
     <ClCompile Include="HitObject.cpp">
       <Filter>Timed Objects\Hit Objects</Filter>
     </ClCompile>
@@ -83,20 +86,26 @@
     <ClCompile Include="NormalNote.cpp">
       <Filter>Timed Objects\Hit Objects</Filter>
     </ClCompile>
-    <ClCompile Include="TimingPoint.cpp">
-      <Filter>Timed Objects\Event Objects</Filter>
-    </ClCompile>
     <ClCompile Include="TimedObject.cpp">
       <Filter>Timed Objects</Filter>
-    </ClCompile>
-    <ClCompile Include="ScrollPoint.cpp">
-      <Filter>Timed Objects\Event Objects</Filter>
     </ClCompile>
     <ClCompile Include="VsrgMap.cpp">
       <Filter>Wrapper Objects</Filter>
     </ClCompile>
     <ClCompile Include="TimedObjectVector.cpp">
-      <Filter>Wrapper Objects</Filter>
+      <Filter>Wrapper Objects\Timed Objects</Filter>
+    </ClCompile>
+    <ClCompile Include="HitObjectVector.cpp">
+      <Filter>Wrapper Objects\Timed Objects</Filter>
+    </ClCompile>
+    <ClCompile Include="EventObject.cpp">
+      <Filter>Timed Objects\Event Objects</Filter>
+    </ClCompile>
+    <ClCompile Include="TimingPoint.cpp">
+      <Filter>Timed Objects\Event Objects</Filter>
+    </ClCompile>
+    <ClCompile Include="ScrollPoint.cpp">
+      <Filter>Timed Objects\Event Objects</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This makes `~HitObject` a virtual destructor, hence making the whole class **abstract**.
HitObject should have never been init-able in the first place

This PR fixes all of the issues pertaining to changing to it.