### PR TITLE
Converts LongNote to inherit from Hit Object

### DIFF
--- a/vsrg/LongNote.h
+++ b/vsrg/LongNote.h
@@ -2,7 +2,7 @@
 #include "HitObject.h"
 #include <vector>
 // Creates a Long/Held Note with 2 Hit Objects
-class LongNote
+class LongNote : public HitObject
 {
 public:
 	/**
@@ -11,47 +11,41 @@ public:
 	 * @param start_ho The start Hit Object as a shared pointer
 	 * @param end_ho The end Hit Object as a shared pointer
 	 */
-	LongNote(SPtrHitObject start_ho, SPtrHitObject end_ho);
-	LongNote(const LongNote & ln);
+	LongNote(double offset_m_sec, unsigned int index, double length);
 	~LongNote();
 	/// Deep Copies the 2 HitObjects into a new LongNote
-	LongNote Clone() const;
+	SPtrTimedObject Clone() const;
 
-	/// Gets a copied shared_ptr of the Start Hit Object
-	SPtrHitObject getStartNote() const;
-	/// Gets a copied shared_ptr of the End Hit Object
-	SPtrHitObject getEndNote() const;
+	// To extend this via aesthetics PR
+	virtual double getLengthMSec();
+	virtual void setLengthMSec(double length_m_sec);
 
-	/// Sets a copied shared_ptr of the Start HitObject
-	void setStartNote(SPtrHitObject start_ho);
-	/// Sets a copied shared_ptr of the End Hit Object
-	void setEndNote(SPtrHitObject end_ho);
+	virtual double getOffsetEndMSec() const;
+	virtual double getOffsetEndSec() const;
+	virtual double getOffsetEndMin() const;
+	virtual double getOffsetEndHour() const;
+	
+	virtual void setOffsetEndMSec(double offset_end_m_sec);
+	virtual void setOffsetEndSec(double offset_end_sec);
+	virtual void setOffsetEndMin(double offset_end_min);
+	virtual void setOffsetEndHour(double offset_end_hour);
 
-	/// Gets the distance between the two Hit Objects
-	virtual double getLength();
     /// If the offset is between the 2 Hit Objects include_ends to include the end points in the range
 	virtual bool isBetween(double offset_m_sec, bool include_ends = false) const;
 
-	virtual bool isOverlapping(const LongNote & ln);
+	virtual bool isOverlapping(const LongNote & ln, bool include_ends = false) const;
 
 	/// Validates the object being realistic
 	virtual bool isValid() const;
-	virtual operator bool() const; // Calls isValid
 
 	/// Gets info of the important object members
 	virtual std::string getInfo() const;
-	virtual operator std::string() const; // Calls toExport
 	/// toExport handles the string exported to files, unlike getInfo which prints more details
 	virtual std::string toExport() const;
 
 	virtual bool operator==(const LongNote & ln) const;
-	LongNote &   operator= (const LongNote & ln);
-
-
-	
 
 private:
-	SPtrHitObject start_ho_;
-	SPtrHitObject end_ho_;
+	double length_m_sec_;
 };
 

--- a/vsrg/VsrgMap.cpp
+++ b/vsrg/VsrgMap.cpp
@@ -10,9 +10,9 @@ std::string VsrgMap::eo_v_tag_ = "// Event Objects";
 VsrgMap::VsrgMap() {}
 VsrgMap::~VsrgMap() {}
 
-void VsrgMap::saveAsVsrg(const std::string & file_path, bool overwrite = false) {
+void VsrgMap::saveAsVsrg(const std::string & file_path, bool overwrite) {
 	if (!overwrite) {
-		BOOST_ASSERT_MSG(!std::filesystem::exists(file_path),
+	BOOST_ASSERT_MSG(!std::filesystem::exists(file_path),
 						 "File already exists.");
 	}
 

--- a/vsrg_ut/HitObjectTest.cpp
+++ b/vsrg_ut/HitObjectTest.cpp
@@ -36,65 +36,26 @@ namespace HitObject_
 	TEST_CLASS(LongNote_)
 	{
 	public:
-		LongNote ln_1 = LongNote(
-			std::make_shared<NormalNote>(NormalNote(100.0, 5)),
-			std::make_shared<NormalNote>(NormalNote(300.0, 5)));
+		LongNote ln_1 = LongNote(100.0, 5, 200.0);
 
-		LongNote ln_2 = LongNote(
-			std::make_shared<NormalNote>(NormalNote(200.0, 6)),
-			std::make_shared<NormalNote>(NormalNote(400.0, 7)));
+		LongNote ln_2 = LongNote(200.0, 6, 200.0);
 
-		LongNote ln_3 = LongNote(
-			std::make_shared<NormalNote>(NormalNote(200.0, 5)),
-			std::make_shared<NormalNote>(NormalNote(400.0, 5)));
+		LongNote ln_3 = LongNote(200.0, 5, 200.0);
 
-		TEST_METHOD(getStartNote)
-		{
-			Assert::AreEqual(100.0, ln_1.getStartNote()->getOffsetMSec());
-
-			SPtrHitObject start_ln = ln_1.getStartNote();
-			start_ln->setOffsetMSec(200.0);
-
-			Assert::AreEqual(200.0, ln_1.getStartNote()->getOffsetMSec());
-		}
-		TEST_METHOD(getEndNote)
-		{
-			Assert::AreEqual(300.0, ln_1.getEndNote()->getOffsetMSec());
-
-			SPtrHitObject end_ln = ln_1.getEndNote();
-			end_ln->setOffsetMSec(200.0);
-
-			Assert::AreEqual(200.0, ln_1.getEndNote()->getOffsetMSec());
-		}
 		TEST_METHOD(Clone)
 		{
-			LongNote ln = ln_1.Clone();
-			Assert::IsFalse(ln.getStartNote().get() == ln_1.getStartNote().get());
-			Assert::IsFalse(ln.getEndNote().get() == ln_1.getEndNote().get());
+			SPtrTimedObject ln = ln_1.Clone();
+			Assert::IsFalse(ln.get() == &ln_1);
 		}
 		TEST_METHOD(isOverlapping) {
 			Assert::IsTrue(ln_1.isOverlapping(ln_3));
-			// TODO: Implement
-			// Assert::ExpectException<std::exception>(ln_1.isOverlapping(ln_2));
 		}
 		TEST_METHOD(isValid)
 		{
-			Assert::IsTrue(bool(LongNote( // Valid
-				std::make_shared<NormalNote>(NormalNote(100.0, 5)),
-				std::make_shared<NormalNote>(NormalNote(200.0, 5)))
-				));
-			Assert::IsFalse(bool(LongNote( // Invalid Note 2
-				std::make_shared<NormalNote>(NormalNote(100.0, 5)),
-				std::make_shared<NormalNote>(NormalNote(-200.0, 5)))
-				));
-			Assert::IsFalse(bool(LongNote( // Mismatched Columns
-				std::make_shared<NormalNote>(NormalNote(100.0, 5)),
-				std::make_shared<NormalNote>(NormalNote(200.0, 6)))
-				));
-			Assert::IsFalse(bool(LongNote( // Invalid Notes
-				std::make_shared<NormalNote>(NormalNote(-100.0, 5)),
-				std::make_shared<NormalNote>(NormalNote(-200.0, 5)))
-				));
+			Assert::IsTrue(bool(LongNote(100.0, 5, 200.0)));
+			Assert::IsFalse(bool(LongNote(100.0, -5, 200.0)));
+			Assert::IsFalse(bool(LongNote(100.0, 5, -200.0)));
+			Assert::IsFalse(bool(LongNote(100.0, -5, -200.0)));
 		}
 		TEST_METHOD(isBetween)
 		{

--- a/vsrg_ut/WrapperObjectTest.cpp
+++ b/vsrg_ut/WrapperObjectTest.cpp
@@ -22,10 +22,8 @@ namespace WrapperObjct_
 		NormalNote nn_1 = NormalNote(100.0, 3);
 		NormalNote nn_2 = NormalNote(200.0, 4);
 
-		LongNote ln_1 = LongNote(std::make_shared<NormalNote>(NormalNote(100.0, 5)),
-								 std::make_shared<NormalNote>(NormalNote(300.0, 5)));
-		LongNote ln_2 = LongNote(std::make_shared<NormalNote>(NormalNote(200.0, 6)),
-								 std::make_shared<NormalNote>(NormalNote(400.0, 7)));
+		LongNote ln_1 = LongNote(100.0, 5, 200.0);
+		LongNote ln_2 = LongNote(200.0, 6, 200.0);
 		HitObjectVector ho_v_1 = HitObjectVector();
 
 		TEST_METHOD(HitObjectVector_vecOps)
@@ -39,12 +37,10 @@ namespace WrapperObjct_
 
 			Assert::AreEqual(size_t(1), ho_v_1.size());
 
-			// LN has 2 objs
-			ho_v_1.push_back(ln_1.getStartNote());
-			ho_v_1.push_back(ln_1.getEndNote());
+			ho_v_1.push_back(std::make_shared<LongNote>(ln_1));
 
 			// Check for polymorphism
-			Assert::AreEqual(size_t(3), ho_v_1.size());
+			Assert::AreEqual(size_t(2), ho_v_1.size());
 
 			ho_v_1.clear();
 


### PR DESCRIPTION
Ran into a few issues when `LongNote` was a wrapper for a pair of `HitObjects`, I feel like it's a bit too specific, non-extensible and error prone. 

I feel like it'd be better if it's converted into a `GroupedHitObject` Class in `vsrg_extend` since it'll be complex **but** easily understandable and inheritable

This PR pretty fixes this and pushes the idea to `vsrg_extend`